### PR TITLE
DOCS-10841 Update ms_composer_about_flows.adoc

### DIFF
--- a/src/docs/ms_composer_about_flows.adoc
+++ b/src/docs/ms_composer_about_flows.adoc
@@ -109,7 +109,6 @@ Data pills allow your data mapping to be as simple or as complex as you need:
 
 * You can create a custom expression instead of simply mapping data pills to data targets, by select *Custom Express fx*. For example, you might want to add some text such as `Copied from Salesforce` after a data pill, to flag it for inspection.
 
-[NOTE]
 If a data pill is a field with a null or blank value, and you map it to an optional field, Composer removes it from the flow. If you map it to a required field, an error occurs because a value is required.
 
 == Flow Controls


### PR DESCRIPTION
Removed the asciidoc NOTE notation as it's not supported in help.salesforce.com.
