### PR TITLE
fix: [W-13488568] Update default format value for fromStringToDateTime and fix missing quote

### DIFF
--- a/en/mulesoft/modules/ROOT/pages/ms_composer_custom_expression_editor.adoc
+++ b/en/mulesoft/modules/ROOT/pages/ms_composer_custom_expression_editor.adoc
@@ -78,9 +78,9 @@ locale: String +
 
 |fromStringToDateTime |Transforms a string input value into a dateTime value.
 Accepts a format and locale. The format parameter represents the format of the input string.
-The default format is `uuuu-MM-dd'T'HH:mm:ss'Z` and the default locale is en-US; however, these defaults can be modified. |`fromStringToDateTime(2021-03-15T23:57:59Z, uuuu-MM-dd'T'HH:mm:ss'Z,US) =  2021-03-15T23:57:59Z` +
+The default format is `uuuu-MM-dd'T'HH:mm:ssz` and the default locale is en-US; however, these defaults can be modified. |`fromStringToDateTime(2021-03-15T23:57:59Z,uuuu-MM-dd'T'HH:mm:ssz,US) =  2021-03-15T23:57:59Z` +
 
-`fromStringToDateTime(2021-03-15 23:57:59Z,uuuu-MM-dd HH:mm:ssz, en-US) = 2021-03-15T23:57:59Z`
+`fromStringToDateTime(2021-03-15 23:57:59Z,uuuu-MM-dd HH:mm:ssz,en-US) = 2021-03-15T23:57:59Z`
 
 |Format: The format parameter represents the format of the input string. This parameter accepts Java character patterns based on ISO-8601. A DateTime value, such as `2011-12-03T10:15:30.000000+01:00`, has the format `uuuu-MM-dd HH:mm:ssz`. +
 
@@ -285,10 +285,10 @@ format: String +
 
 locale: String |String
 
-|fromDateTimeToString |Transforms a dateTime input value into a string value. Accepts a format and locale. The format parameter represents the desired format of the output string. The default format is `uuuu-MM-dd'T'HH:mm:ss'Z`
- and the default locale is en-US; however, these defaults can be modified. |`fromDateTimeToString(2021-03-15T23:57:59Z, uuuu-MM-dd'T'HH:mm:ss'Z, en-US) = 2021-03-15T23:57:59Z` +
+|fromDateTimeToString |Transforms a dateTime input value into a string value. Accepts a format and locale. The format parameter represents the desired format of the output string. The default format is `uuuu-MM-dd'T'HH:mm:ss'Z'`
+ and the default locale is en-US; however, these defaults can be modified. |`fromDateTimeToString(2021-03-15T23:57:59Z, uuuu-MM-dd'T'HH:mm:ss'Z', en-US) = 2021-03-15T23:57:59Z` +
 
-`fromDateTimeToString(2021-03-15T23:57:59Z, MMMM dd, ES) = marzo 15` |Format: The ISO-8601 formatting to use on the DateTime. It represents the desired format of the output string. For example, this parameter accepts character patterns based on the Java 8 java.time.format. The default format is `uuuu-MM-dd'T'HH:mm:ss'Z`.
+`fromDateTimeToString(2021-03-15T23:57:59Z, MMMM dd, ES) = marzo 15` |Format: The ISO-8601 formatting to use on the DateTime. It represents the desired format of the output string. For example, this parameter accepts character patterns based on the Java 8 java.time.format. The default format is `uuuu-MM-dd'T'HH:mm:ss'Z'`.
  +
 
 Locale: Optional ISO 3166 country code to use, such as `en-US`, `AR`, or `ES`. When you pass a translatable format, such as `eeee` and `MMMM`, a locale (such as `ES`) transforms the corresponding numeric values to a localized string. |dateTime: DateTime +

--- a/jp/mulesoft/modules/ROOT/pages/ms_composer_custom_expression_editor.adoc
+++ b/jp/mulesoft/modules/ROOT/pages/ms_composer_custom_expression_editor.adoc
@@ -78,9 +78,9 @@ locale: String +
 
 |fromStringToDateTime |文字列入力値を日時値に変換します。
 形式とロケールを受け入れます。形式パラメータは、入力文字列の形式を表します。
-デフォルトの形式は ​`uuuu-MM-dd'T'HH:mm:ss'Z`​ で、デフォルトのロケールは en-US です。ただし、これらのデフォルトは変更できます。 |`fromStringToDateTime(2021-03-15T23:57:59Z, uuuu-MM-dd'T'HH:mm:ss'Z,US) =  2021-03-15T23:57:59Z` +
+デフォルトの形式は ​`uuuu-MM-dd'T'HH:mm:ssz`​ で、デフォルトのロケールは en-US です。ただし、これらのデフォルトは変更できます。 |`fromStringToDateTime(2021-03-15T23:57:59Z,uuuu-MM-dd'T'HH:mm:ssz,US) =  2021-03-15T23:57:59Z` +
 
-`fromStringToDateTime(2021-03-15 23:57:59Z,uuuu-MM-dd HH:mm:ssz, en-US) = 2021-03-15T23:57:59Z`​
+`fromStringToDateTime(2021-03-15 23:57:59Z,uuuu-MM-dd HH:mm:ssz,en-US) = 2021-03-15T23:57:59Z`​
 
 |Format (形式): 形式パラメータは、入力文字列の形式を表します。このパラメータでは、ISO-8601 に基づいた Java 文字パターンを受け入れます。​`2011-12-03T10:15:30.000000+01:00`​ などの日時値の形式は ​`uuuu-MM-dd HH:mm:ssz`​ となります。 +
 
@@ -276,9 +276,9 @@ format: String +
 
 locale: String |String (文字列)
 
-|fromDateTimeToString |日時入力値を文字列値に変換します。形式とロケールを受け入れます。形式パラメータは、出力文字列の目的の形式を表します。デフォルトの形式は ​`uuuu-MM-dd'T'HH:mm:ss'Z`​ で、デフォルトのロケールは en-US です。ただし、これらのデフォルトは変更できます。 |`fromDateTimeToString(2021-03-15T23:57:59Z, uuuu-MM-dd'T'HH:mm:ss'Z, en-US) = 2021-03-15T23:57:59Z` +
+|fromDateTimeToString |日時入力値を文字列値に変換します。形式とロケールを受け入れます。形式パラメータは、出力文字列の目的の形式を表します。デフォルトの形式は ​`uuuu-MM-dd'T'HH:mm:ss'Z'`​ で、デフォルトのロケールは en-US です。ただし、これらのデフォルトは変更できます。 |`fromDateTimeToString(2021-03-15T23:57:59Z, uuuu-MM-dd'T'HH:mm:ss'Z', en-US) = 2021-03-15T23:57:59Z` +
 
-`fromDateTimeToString(2021-03-15T23:57:59Z, MMMM dd, ES) = marzo 15` |Format (形式): 日時で使用する ISO-8601 形式。出力文字列の目的の形式を表します。たとえば、このパラメータでは Java 8 の java.time.format に基づいた文字パターンを受け入れます。デフォルト形式は ​`uuuu-MM-dd'T'HH:mm:ss'Z`​ です。
+`fromDateTimeToString(2021-03-15T23:57:59Z, MMMM dd, ES) = marzo 15` |Format (形式): 日時で使用する ISO-8601 形式。出力文字列の目的の形式を表します。たとえば、このパラメータでは Java 8 の java.time.format に基づいた文字パターンを受け入れます。デフォルト形式は ​`uuuu-MM-dd'T'HH:mm:ss'Z'`​ です。
  +
 
 Locale (ロケール): 使用する省略可能な ISO 3166 国コード (​`en-US`​、​`AR`​、​`ES`​ など)。​`eeee`​ や ​`MMMM`​ などの翻訳可能な形式を渡すと、ロケール (​`ES`​ など) は対応する数値をローカライズ済みの文字列に変換します。|dateTime: DateTime +

--- a/jp/mulesoft/modules/ROOT/pages/ms_composer_custom_expression_editor.adoc
+++ b/jp/mulesoft/modules/ROOT/pages/ms_composer_custom_expression_editor.adoc
@@ -78,9 +78,9 @@ locale: String +
 
 |fromStringToDateTime |文字列入力値を日時値に変換します。
 形式とロケールを受け入れます。形式パラメータは、入力文字列の形式を表します。
-デフォルトの形式は ​`uuuu-MM-dd'T'HH:mm:ssz`​ で、デフォルトのロケールは en-US です。ただし、これらのデフォルトは変更できます。 |`fromStringToDateTime(2021-03-15T23:57:59Z,uuuu-MM-dd'T'HH:mm:ssz,US) =  2021-03-15T23:57:59Z` +
+デフォルトの形式は ​`uuuu-MM-dd'T'HH:mm:ss'Z`​ で、デフォルトのロケールは en-US です。ただし、これらのデフォルトは変更できます。 |`fromStringToDateTime(2021-03-15T23:57:59Z, uuuu-MM-dd'T'HH:mm:ss'Z,US) =  2021-03-15T23:57:59Z` +
 
-`fromStringToDateTime(2021-03-15 23:57:59Z,uuuu-MM-dd HH:mm:ssz,en-US) = 2021-03-15T23:57:59Z`​
+`fromStringToDateTime(2021-03-15 23:57:59Z,uuuu-MM-dd HH:mm:ssz, en-US) = 2021-03-15T23:57:59Z`​
 
 |Format (形式): 形式パラメータは、入力文字列の形式を表します。このパラメータでは、ISO-8601 に基づいた Java 文字パターンを受け入れます。​`2011-12-03T10:15:30.000000+01:00`​ などの日時値の形式は ​`uuuu-MM-dd HH:mm:ssz`​ となります。 +
 
@@ -276,9 +276,9 @@ format: String +
 
 locale: String |String (文字列)
 
-|fromDateTimeToString |日時入力値を文字列値に変換します。形式とロケールを受け入れます。形式パラメータは、出力文字列の目的の形式を表します。デフォルトの形式は ​`uuuu-MM-dd'T'HH:mm:ss'Z'`​ で、デフォルトのロケールは en-US です。ただし、これらのデフォルトは変更できます。 |`fromDateTimeToString(2021-03-15T23:57:59Z, uuuu-MM-dd'T'HH:mm:ss'Z', en-US) = 2021-03-15T23:57:59Z` +
+|fromDateTimeToString |日時入力値を文字列値に変換します。形式とロケールを受け入れます。形式パラメータは、出力文字列の目的の形式を表します。デフォルトの形式は ​`uuuu-MM-dd'T'HH:mm:ss'Z`​ で、デフォルトのロケールは en-US です。ただし、これらのデフォルトは変更できます。 |`fromDateTimeToString(2021-03-15T23:57:59Z, uuuu-MM-dd'T'HH:mm:ss'Z, en-US) = 2021-03-15T23:57:59Z` +
 
-`fromDateTimeToString(2021-03-15T23:57:59Z, MMMM dd, ES) = marzo 15` |Format (形式): 日時で使用する ISO-8601 形式。出力文字列の目的の形式を表します。たとえば、このパラメータでは Java 8 の java.time.format に基づいた文字パターンを受け入れます。デフォルト形式は ​`uuuu-MM-dd'T'HH:mm:ss'Z'`​ です。
+`fromDateTimeToString(2021-03-15T23:57:59Z, MMMM dd, ES) = marzo 15` |Format (形式): 日時で使用する ISO-8601 形式。出力文字列の目的の形式を表します。たとえば、このパラメータでは Java 8 の java.time.format に基づいた文字パターンを受け入れます。デフォルト形式は ​`uuuu-MM-dd'T'HH:mm:ss'Z`​ です。
  +
 
 Locale (ロケール): 使用する省略可能な ISO 3166 国コード (​`en-US`​、​`AR`​、​`ES`​ など)。​`eeee`​ や ​`MMMM`​ などの翻訳可能な形式を渡すと、ロケール (​`ES`​ など) は対応する数値をローカライズ済みの文字列に変換します。|dateTime: DateTime +


### PR DESCRIPTION
This PR updates the default format value for `fromStringToDateTime` function in the custom expression editor. Also added some missing closing `'` in the text for `fromDateTimeToString`. Updated both `en` and `jp` pages.

# Writer's Quality Checklist

Before merging your PR, did you:

- [ ] Run spell checker
- [ ] Run link checker to check for broken xrefs
- [ ] Check for orphan files
- [ ] Perform a local build and do a final visual check of your content, including checking for:
  - Broken images
  - Dead links
  - Correct rendering of partials if they are used in your content
  - Formatting issues, such as:
    - Misnumbered ordered lists (steps) or incorrectly nested unordered lists
    - Messed up tables
    - Proper indentation
    - Correct header levels
- [ ] Receive final review and signoff from:
  - Technical SME
  - Product Manager
  - Editor or peer reviewer
  - Reporter, if this content is in response to a reported issue (internal or external feedback)
- [ ] If applicable, verify that the software actually got released