### PR TITLE
[W-18710315] Add missing symlinks

### DIFF
--- a/en/salesforce/modules/ROOT/pages/ms_composer_automation_credits_2.adoc
+++ b/en/salesforce/modules/ROOT/pages/ms_composer_automation_credits_2.adoc
@@ -1,0 +1,1 @@
+../../../../mulesoft/modules/ROOT/pages/ms_composer_automation_credits_2.adoc

--- a/en/salesforce/modules/ROOT/pages/ms_composer_hyperautomation.adoc
+++ b/en/salesforce/modules/ROOT/pages/ms_composer_hyperautomation.adoc
@@ -1,0 +1,1 @@
+../../../../mulesoft/modules/ROOT/pages/ms_composer_hyperautomation.adoc

--- a/jp/salesforce/modules/ROOT/pages/ms_composer_hyperautomation.adoc
+++ b/jp/salesforce/modules/ROOT/pages/ms_composer_hyperautomation.adoc
@@ -1,0 +1,1 @@
+../../../../mulesoft/modules/ROOT/pages/ms_composer_hyperautomation.adoc


### PR DESCRIPTION
Added symlinks to fix these errors in the build:

```
target of xref not found: ms_composer_hyperautomation.adoc
target of xref not found: ms_composer_automation_credits_2.adoc
```

Note that the JP content does not have the second topic translated or in the nav. As a result, I'm only creating one symlink for JP.

Confirmed in a local build that the errors are gone and that the topics display in the Composer for Salesforce help nav.

